### PR TITLE
Add Discord readiness tracking and expand diagnostic logging

### DIFF
--- a/src/Invocables/KickStaleInvokable.cs
+++ b/src/Invocables/KickStaleInvokable.cs
@@ -23,7 +23,8 @@ internal class KickStaleInvokable(
     DB db,
     ILogger<KickStaleInvokable> logger,
     IGuildConfigService guildConfigService,
-    IDiscordClientService discord)
+    IDiscordClientService discord,
+    IDiscordReadinessService readiness)
     : IInvocable
 {
     public async Task Invoke()
@@ -37,7 +38,19 @@ internal class KickStaleInvokable(
         {
             if (!discord.Client.Guilds.TryGetValue(config1.GuildId, out DiscordGuild guild))
             {
-                logger.LogWarning("Guild {GuildId} not present in client, skipping stale kick", config1.GuildId);
+                // If GuildAvailable has never fired for this guild the client cache is still
+                // being populated (startup race). Log at Debug to avoid false-alarm warnings.
+                // Once the guild has been seen at least once, a missing entry is a real problem.
+                if (readiness.IsGuildReady(config1.GuildId))
+                {
+                    logger.LogWarning("Guild {GuildId} not present in client, skipping stale kick", config1.GuildId);
+                }
+                else
+                {
+                    logger.LogDebug("Guild {GuildId} not yet available in client (startup), skipping stale kick",
+                        config1.GuildId);
+                }
+
                 continue;
             }
 
@@ -75,7 +88,9 @@ internal class KickStaleInvokable(
 
             foreach (GuildMember guildMember in staleMembers)
             {
-                logger.LogInformation("Processing stale member {MemberId}", guildMember.MemberId);
+                logger.LogInformation(
+                    "Initiating auto-kick of stale member {MemberId} (current status {Status}, widget created {CreatedAt})",
+                    guildMember.MemberId, guildMember.Status, guildMember.Application?.CreatedAt);
 
                 DiscordMember member;
 
@@ -99,9 +114,10 @@ internal class KickStaleInvokable(
 
                 try
                 {
+                    logger.LogInformation("Calling RemoveAsync for stale member {MemberId}", guildMember.MemberId);
                     await member.RemoveAsync("Member removed due to idle timeout");
 
-                    logger.LogWarning("Removed {@Member} due to idle timeout", guildMember);
+                    logger.LogInformation("Auto-kicked stale member {MemberId} due to idle timeout", guildMember.MemberId);
                 }
                 catch (NotFoundException)
                 {

--- a/src/Modules/ApplicationWorkflow.GuildBanAdded.cs
+++ b/src/Modules/ApplicationWorkflow.GuildBanAdded.cs
@@ -40,6 +40,9 @@ internal partial class ApplicationWorkflow : IDiscordGuildBanAddedEventSubscribe
             or MemberStatus.BannedByHoneypot
             or MemberStatus.BannedExternally)
         {
+            logger.LogInformation(
+                "GuildBanAdded for {Member} skipped: status already {Status}",
+                e.Member, member.Status);
             return;
         }
 

--- a/src/Modules/ApplicationWorkflow.MemberRemoved.cs
+++ b/src/Modules/ApplicationWorkflow.MemberRemoved.cs
@@ -25,7 +25,13 @@ internal partial class ApplicationWorkflow
             return;
         }
 
-        logger.LogInformation("{Member} left", e.Member);
+        string roles = e.Member.Roles.Any()
+            ? string.Join(", ", e.Member.Roles.Select(r => $"{r.Name}({r.Id})"))
+            : "(none)";
+
+        logger.LogInformation(
+            "{Member} left — Discord roles at removal: [{Roles}], Discord joined {DiscordJoinedAt}",
+            e.Member, roles, e.Member.JoinedAt);
 
         GuildMember member = await db.Find<GuildMember>().OneAsync(e.ToEntityId());
 
@@ -41,11 +47,23 @@ internal partial class ApplicationWorkflow
             // terminal cause (mod kick, ban, auto-kick, honeypot) has already been set.
             // For un-migrated documents (Status == Unknown) the legacy timestamp fields
             // are the source of truth — check them before overwriting with LeftVoluntarily.
+            MemberStatusEvent lastEvent = member.StatusHistory.LastOrDefault();
+
             logger.LogInformation(
-                "Member {Member} departure: loaded status {Status}, RemovedByModeration={RemovedByModeration}, " +
-                "KickedAt={KickedAt}, BannedAt={BannedAt}, AutoKickedAt={AutoKickedAt}, history depth {HistoryDepth}",
-                e.Member, member.Status, member.RemovedByModeration,
-                member.KickedAt, member.BannedAt, member.AutoKickedAt, member.StatusHistory.Count);
+                "Member {Member} departure snapshot — " +
+                "status={Status} since {StatusChangedAt} (reason={StatusReason}), " +
+                "RemovedByModeration={RemovedByModeration}, " +
+                "KickedAt={KickedAt}, BannedAt={BannedAt}, AutoKickedAt={AutoKickedAt}, " +
+                "JoinedAt={JoinedAt}, HasApplication={HasApplication}, HasChannel={HasChannel}, " +
+                "historyDepth={HistoryDepth}, " +
+                "lastTransition=[{LastFrom}->{LastTo} at {LastAt} actor={LastActor} reason={LastReason}]",
+                e.Member,
+                member.Status, member.StatusChangedAt, member.StatusReason,
+                member.RemovedByModeration,
+                member.KickedAt, member.BannedAt, member.AutoKickedAt,
+                member.JoinedAt, member.Application is not null, member.Channel is not null,
+                member.StatusHistory.Count,
+                lastEvent?.From, lastEvent?.To, lastEvent?.At, lastEvent?.ActorId, lastEvent?.Reason);
 
             if (IsEligibleForVoluntaryLeave(member))
             {

--- a/src/Modules/ApplicationWorkflow.MemberRemoved.cs
+++ b/src/Modules/ApplicationWorkflow.MemberRemoved.cs
@@ -41,8 +41,16 @@ internal partial class ApplicationWorkflow
             // terminal cause (mod kick, ban, auto-kick, honeypot) has already been set.
             // For un-migrated documents (Status == Unknown) the legacy timestamp fields
             // are the source of truth — check them before overwriting with LeftVoluntarily.
+            logger.LogInformation(
+                "Member {Member} departure: loaded status {Status}, RemovedByModeration={RemovedByModeration}, " +
+                "KickedAt={KickedAt}, BannedAt={BannedAt}, AutoKickedAt={AutoKickedAt}, history depth {HistoryDepth}",
+                e.Member, member.Status, member.RemovedByModeration,
+                member.KickedAt, member.BannedAt, member.AutoKickedAt, member.StatusHistory.Count);
+
             if (IsEligibleForVoluntaryLeave(member))
             {
+                logger.LogInformation("Classifying {Member} as voluntary leave (status was {Status})",
+                    e.Member, member.Status);
                 await member.TransitionToAsync(db, MemberStatus.LeftVoluntarily);
             }
             else
@@ -50,6 +58,9 @@ internal partial class ApplicationWorkflow
                 // Terminal state was already set (e.g. by honeypot, KickStaleInvokable, or a
                 // panel action that fired before the Discord event arrived). Just stamp LeftAt
                 // for legacy queries without overwriting the canonical status.
+                logger.LogInformation(
+                    "Preserving terminal status {Status} for {Member}, stamping LeftAt only",
+                    member.Status, e.Member);
                 member.LeftAt = DateTime.UtcNow;
                 await db.SaveAsync(member);
             }

--- a/src/Modules/ApplicationWorkflow.cs
+++ b/src/Modules/ApplicationWorkflow.cs
@@ -241,8 +241,8 @@ internal partial class ApplicationWorkflow(
         GuildMember entry,
         DiscordMember member)
     {
-        logger.LogInformation("{User} banned {Member}",
-            args.User, member);
+        logger.LogInformation("{User} initiating ban of {Member} (current status {Status})",
+            args.User, member, entry.Status);
 
         // Pre-mark in DB so that the GuildMemberRemoved event that fires immediately
         // after BanAsync sees the correct terminal status even if this process restarts.
@@ -253,6 +253,8 @@ internal partial class ApplicationWorkflow(
         try
         {
             await member.BanAsync();
+
+            logger.LogInformation("{Member} ban completed by {User}", member, args.User);
         }
         catch (Exception ex)
         {
@@ -280,8 +282,8 @@ internal partial class ApplicationWorkflow(
         GuildMember entry,
         DiscordMember member)
     {
-        logger.LogInformation("{User} kicked {Member}",
-            args.User, member);
+        logger.LogInformation("{User} initiating kick of {Member} (current status {Status})",
+            args.User, member, entry.Status);
 
         // Pre-mark in DB so that the GuildMemberRemoved event that fires immediately
         // after RemoveAsync sees the correct terminal status even if this process restarts.
@@ -292,6 +294,8 @@ internal partial class ApplicationWorkflow(
         try
         {
             await member.RemoveAsync();
+
+            logger.LogInformation("{Member} kick completed by {User}", member, args.User);
         }
         catch (Exception ex)
         {

--- a/src/Modules/HoneypotModule.cs
+++ b/src/Modules/HoneypotModule.cs
@@ -85,6 +85,11 @@ internal sealed class HoneypotModule(DB db, IGuildConfigService guildConfigServi
             }
 
             MemberStatus previousStatus = guildMember.Status;
+
+            logger.LogInformation(
+                "Honeypot triggered by {Member} (existing document: {Existing}, prior status {Previous})",
+                member, !isNewDocument, previousStatus);
+
             await guildMember.TransitionToAsync(db, MemberStatus.BannedByHoneypot, "honeypot");
 
             // yeet!

--- a/src/Modules/IgorCoreModule.cs
+++ b/src/Modules/IgorCoreModule.cs
@@ -1,6 +1,8 @@
 ﻿using DSharpPlus;
 using DSharpPlus.EventArgs;
 
+using IgorBot.Services;
+
 using JetBrains.Annotations;
 
 using Nefarius.DSharpPlus.Extensions.Hosting.Events;
@@ -9,10 +11,13 @@ namespace IgorBot.Modules;
 
 [DiscordGuildAvailableEventSubscriber]
 [UsedImplicitly]
-internal class IgorCoreModule(ILogger<IgorCoreModule> logger) : IDiscordGuildAvailableEventSubscriber
+internal class IgorCoreModule(ILogger<IgorCoreModule> logger, IDiscordReadinessService readiness)
+    : IDiscordGuildAvailableEventSubscriber
 {
     public Task DiscordOnGuildAvailable(DiscordClient sender, GuildCreateEventArgs args)
     {
+        readiness.MarkGuildAvailable(args.Guild.Id);
+
         logger.LogInformation("{Guild} online", args.Guild);
 
         return Task.CompletedTask;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -43,6 +43,8 @@ IHostBuilder builder = Host.CreateDefaultBuilder(args)
         bool migrationDryRun = hostContext.Configuration.GetValue<bool>("Bot:Migration:DryRun");
         GuildMemberStatusMigration.RunAsync(db, migrationDryRun).GetAwaiter().GetResult();
 
+        services.AddSingleton<IDiscordReadinessService, DiscordReadinessService>();
+
         services.AddSingleton<GuildConfigService>();
         services.AddSingleton<IGuildConfigService>(sp =>
             new CachedGuildConfigService(

--- a/src/Schema/GuildMember.PublicMethods.cs
+++ b/src/Schema/GuildMember.PublicMethods.cs
@@ -4,6 +4,8 @@ using DSharpPlus.EventArgs;
 
 using MongoDB.Entities;
 
+using Serilog;
+
 namespace IgorBot.Schema;
 
 internal sealed partial class GuildMember
@@ -26,6 +28,10 @@ internal sealed partial class GuildMember
         {
             return;
         }
+
+        Log.Information(
+            "GuildMember {MemberId} transitioning {From} -> {To} reason={Reason} actor={ActorId}",
+            ID, Status, next, reason, actorId);
 
         DateTime now = DateTime.UtcNow;
 
@@ -89,6 +95,10 @@ internal sealed partial class GuildMember
 
         await update.ExecuteAsync();
 
+        Log.Information(
+            "GuildMember {MemberId} transitioned {From} -> {To}",
+            ID, Status, next);
+
         // Mirror to in-memory state only after the DB write succeeded so the
         // in-memory object never gets ahead of what is persisted.
         // Clear all legacy fields first, matching the DB update above.
@@ -144,6 +154,10 @@ internal sealed partial class GuildMember
     {
         const string rejoinReason = "rejoin";
         DateTime now = DateTime.UtcNow;
+
+        Log.Information(
+            "GuildMember {MemberId} Reset from {PreviousStatus} (rejoin)",
+            ID, Status);
 
         // Record the rejoin before wiping the lifecycle fields so the history
         // shows what state the member was in when they came back.

--- a/src/Services/DiscordReadinessService.cs
+++ b/src/Services/DiscordReadinessService.cs
@@ -1,0 +1,15 @@
+using System.Collections.Concurrent;
+
+namespace IgorBot.Services;
+
+/// <inheritdoc />
+internal sealed class DiscordReadinessService : IDiscordReadinessService
+{
+    private readonly ConcurrentDictionary<ulong, bool> _readyGuilds = new();
+
+    /// <inheritdoc />
+    public void MarkGuildAvailable(ulong guildId) => _readyGuilds[guildId] = true;
+
+    /// <inheritdoc />
+    public bool IsGuildReady(ulong guildId) => _readyGuilds.ContainsKey(guildId);
+}

--- a/src/Services/GuildMemberStatusMigration.cs
+++ b/src/Services/GuildMemberStatusMigration.cs
@@ -52,6 +52,9 @@ internal static class GuildMemberStatusMigration
                 continue;
             }
 
+            Log.Information("Migrating {MemberId} {Unknown} -> {Derived} at {At}",
+                member.ID, MemberStatus.Unknown, derivedStatus, derivedAt);
+
             member.Status = derivedStatus;
             member.StatusChangedAt = derivedAt;
 

--- a/src/Services/IDiscordReadinessService.cs
+++ b/src/Services/IDiscordReadinessService.cs
@@ -1,0 +1,23 @@
+namespace IgorBot.Services;
+
+/// <summary>
+///     Tracks which guilds have fired their <c>GuildAvailable</c> event after the Discord
+///     client connected. Used to distinguish the startup-race window (where
+///     <see cref="Nefarius.DSharpPlus.Extensions.Hosting.IDiscordClientService" />'s
+///     <c>Guilds</c> dictionary is not yet populated) from a genuine runtime condition
+///     where the bot is no longer in a guild.
+/// </summary>
+internal interface IDiscordReadinessService
+{
+    /// <summary>
+    ///     Records that <paramref name="guildId" /> has become available and its data is
+    ///     present in the Discord client cache.
+    /// </summary>
+    void MarkGuildAvailable(ulong guildId);
+
+    /// <summary>
+    ///     Returns <c>true</c> when <paramref name="guildId" /> has been seen at least once
+    ///     via <see cref="MarkGuildAvailable" /> since the process started.
+    /// </summary>
+    bool IsGuildReady(ulong guildId);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guild readiness tracking to detect when guild data is available in the Discord client.
  * Registered a readiness service for runtime guild availability checks.

* **Improvements**
  * Expanded and clarified diagnostic logging across moderation flows, honeypot triggers, migrations, and member lifecycle events (more context before/after actions).

* **Bug Fixes**
  * Better handling and log-level differentiation when guild data is missing during startup vs normal runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/IgorBot/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->