### PR TITLE
Handle Discord kicks via audit log and add member removal concurrency mitigation

### DIFF
--- a/src/Modules/ApplicationWorkflow.MemberRemoved.cs
+++ b/src/Modules/ApplicationWorkflow.MemberRemoved.cs
@@ -25,6 +25,8 @@ internal partial class ApplicationWorkflow
             return;
         }
 
+        // Capture Discord-side state immediately — roles and join date are unavailable
+        // after the member leaves, so log them here before the DB lookup.
         string roles = e.Member.Roles.Any()
             ? string.Join(", ", e.Member.Roles.Select(r => $"{r.Name}({r.Id})"))
             : "(none)";
@@ -33,7 +35,8 @@ internal partial class ApplicationWorkflow
             "{Member} left — Discord roles at removal: [{Roles}], Discord joined {DiscordJoinedAt}",
             e.Member, roles, e.Member.JoinedAt);
 
-        GuildMember member = await db.Find<GuildMember>().OneAsync(e.ToEntityId());
+        string entityId = $"{e.Guild.Id}-{e.Member.Id}";
+        GuildMember member = await db.Find<GuildMember>().OneAsync(entityId);
 
         if (member is null)
         {
@@ -47,6 +50,17 @@ internal partial class ApplicationWorkflow
             // terminal cause (mod kick, ban, auto-kick, honeypot) has already been set.
             // For un-migrated documents (Status == Unknown) the legacy timestamp fields
             // are the source of truth — check them before overwriting with LeftVoluntarily.
+
+            // When the initially-loaded status is still non-terminal, a concurrent handler
+            // (AuditLogKickHandler for external kicks, or GuildBanAdded for external bans)
+            // may be writing a terminal status to the DB right now. Wait briefly then
+            // re-fetch so we see their result before making the classification decision.
+            if (IsEligibleForVoluntaryLeave(member))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(500));
+                member = await db.Find<GuildMember>().OneAsync(entityId) ?? member;
+            }
+
             MemberStatusEvent lastEvent = member.StatusHistory.LastOrDefault();
 
             logger.LogInformation(

--- a/src/Modules/AuditLogKickHandler.cs
+++ b/src/Modules/AuditLogKickHandler.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+
+using DSharpPlus;
+using DSharpPlus.EventArgs;
+
+using IgorBot.Schema;
+using IgorBot.Services;
+
+using JetBrains.Annotations;
+
+using MongoDB.Entities;
+
+using Nefarius.DSharpPlus.Extensions.Hosting.Events;
+
+namespace IgorBot.Modules;
+
+/// <summary>
+///     Handles <c>GUILD_AUDIT_LOG_ENTRY_CREATE</c> gateway events, which DSharpPlus 4.5.1
+///     does not natively parse. When a kick (action_type 20) is detected, the member is
+///     pre-marked as <see cref="MemberStatus.KickedExternally" /> in the database before the
+///     subsequent <c>GUILD_MEMBER_REMOVE</c> event fires. This prevents
+///     <see cref="ApplicationWorkflow.DiscordOnGuildMemberRemoved" /> from misclassifying
+///     the departure as a voluntary leave.
+/// </summary>
+[DiscordUnknownEventEventSubscriber]
+[UsedImplicitly]
+internal sealed class AuditLogKickHandler(
+    DB db,
+    ILogger<AuditLogKickHandler> logger,
+    IGuildConfigService guildConfigService)
+    : IDiscordUnknownEventEventSubscriber
+{
+    // Discord audit log action type for MEMBER_KICK.
+    private const int MemberKickActionType = 20;
+
+    public async Task DiscordOnUnknownEvent(DiscordClient sender, UnknownEventArgs args)
+    {
+        if (args.EventName != "GUILD_AUDIT_LOG_ENTRY_CREATE")
+        {
+            return;
+        }
+
+        ulong guildId;
+        ulong targetId;
+        ulong? actorId = null;
+        string reason = null;
+
+        try
+        {
+            using JsonDocument doc = JsonDocument.Parse(args.Json);
+            JsonElement root = doc.RootElement;
+
+            if (!root.TryGetProperty("action_type", out JsonElement actionTypeEl) ||
+                actionTypeEl.GetInt32() != MemberKickActionType)
+            {
+                return;
+            }
+
+            if (!root.TryGetProperty("guild_id", out JsonElement guildIdEl) ||
+                !ulong.TryParse(guildIdEl.GetString(), out guildId))
+            {
+                logger.LogWarning("GUILD_AUDIT_LOG_ENTRY_CREATE (kick) missing or invalid guild_id");
+                return;
+            }
+
+            if (!root.TryGetProperty("target_id", out JsonElement targetIdEl) ||
+                !ulong.TryParse(targetIdEl.GetString(), out targetId))
+            {
+                logger.LogWarning("GUILD_AUDIT_LOG_ENTRY_CREATE (kick) missing or invalid target_id");
+                return;
+            }
+
+            if (root.TryGetProperty("user_id", out JsonElement userIdEl) &&
+                ulong.TryParse(userIdEl.GetString(), out ulong parsedActorId))
+            {
+                actorId = parsedActorId;
+            }
+
+            if (root.TryGetProperty("reason", out JsonElement reasonEl))
+            {
+                reason = reasonEl.GetString();
+            }
+        }
+        catch (JsonException ex)
+        {
+            logger.LogError(ex, "Failed to parse GUILD_AUDIT_LOG_ENTRY_CREATE payload");
+            return;
+        }
+
+        if (await guildConfigService.GetAsync(guildId) is null)
+        {
+            return;
+        }
+
+        string entityId = $"{guildId}-{targetId}";
+        GuildMember member = await db.Find<GuildMember>().OneAsync(entityId);
+
+        if (member is null)
+        {
+            logger.LogDebug(
+                "GUILD_AUDIT_LOG_ENTRY_CREATE (kick): member {TargetId} in guild {GuildId} not found in DB, skipping",
+                targetId, guildId);
+            return;
+        }
+
+        // Only pre-mark when the member is in a non-terminal state. If a terminal status
+        // is already set (e.g. the bot panel kicked them), don't overwrite it.
+        if (member.Status is not (MemberStatus.New or MemberStatus.Onboarding or
+            MemberStatus.QuestionnaireSubmitted or MemberStatus.FullMember or
+            MemberStatus.StrangerRoleRemoved or MemberStatus.Unknown))
+        {
+            logger.LogInformation(
+                "GUILD_AUDIT_LOG_ENTRY_CREATE (kick) for {TargetId}: status already {Status}, skipping pre-mark",
+                targetId, member.Status);
+            return;
+        }
+
+        logger.LogInformation(
+            "External kick detected via audit log: member {TargetId} in guild {GuildId} kicked by actor {ActorId} (reason={Reason}). Pre-marking as KickedExternally.",
+            targetId, guildId, actorId, reason);
+
+        await member.TransitionToAsync(db, MemberStatus.KickedExternally,
+            reason: reason ?? "external kick via audit log",
+            actorId: actorId);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic detection and logging of member kicks through Discord's audit log, ensuring member status is updated when external removals occur.

* **Improvements**
  * Improved member departure handling with enhanced concurrency management, including retry logic to ensure accurate classification of member statuses during simultaneous events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/IgorBot/pull/136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->