### PR TITLE
Make legacy voluntary leaves explicit

### DIFF
--- a/src/Invocables/MemberDbSyncInvokable.cs
+++ b/src/Invocables/MemberDbSyncInvokable.cs
@@ -72,17 +72,29 @@ internal class MemberDbSyncInvokable(
                     }
 
                     // add missing
+                    DateTime now = DateTime.UtcNow;
                     guildMember = new GuildMember
                     {
                         GuildId = member.Guild.Id,
                         MemberId = member.Id,
                         Member = member.ToString(),
-                        Mention = member.Mention
+                        Mention = member.Mention,
+                        Status = MemberStatus.New,
+                        StatusChangedAt = now,
+                        StatusReason = "discovered_by_sync"
                     };
+                    guildMember.StatusHistory.Add(new MemberStatusEvent
+                    {
+                        From = MemberStatus.Unknown,
+                        To = MemberStatus.New,
+                        At = now,
+                        Reason = "discovered_by_sync"
+                    });
 
                     await db.SaveAsync(guildMember);
 
-                    logger.LogInformation("{Member} added to DB", member);
+                    logger.LogInformation("{Member} added to DB by sync (stamped Status={Status})", member,
+                        MemberStatus.New);
                 }
             }
 

--- a/src/Invocables/MemberDbSyncInvokable.cs
+++ b/src/Invocables/MemberDbSyncInvokable.cs
@@ -81,14 +81,14 @@ internal class MemberDbSyncInvokable(
                         Mention = member.Mention,
                         Status = MemberStatus.New,
                         StatusChangedAt = now,
-                        StatusReason = "discovered_by_sync"
+                        StatusReason = MemberLifecycleClassifier.DiscoveredBySyncReason
                     };
                     guildMember.StatusHistory.Add(new MemberStatusEvent
                     {
                         From = MemberStatus.Unknown,
                         To = MemberStatus.New,
                         At = now,
-                        Reason = "discovered_by_sync"
+                        Reason = MemberLifecycleClassifier.DiscoveredBySyncReason
                     });
 
                     await db.SaveAsync(guildMember);

--- a/src/Modules/ApplicationWorkflow.MemberRemoved.cs
+++ b/src/Modules/ApplicationWorkflow.MemberRemoved.cs
@@ -85,9 +85,19 @@ internal partial class ApplicationWorkflow
 
             if (IsEligibleForVoluntaryLeave(member))
             {
-                logger.LogInformation("Classifying {Member} as voluntary leave (status was {Status})",
-                    e.Member, member.Status);
-                await member.TransitionToAsync(db, MemberStatus.LeftVoluntarily);
+                VoluntaryLeavePath path = ClassifyVoluntaryLeavePath(member);
+                string reason = path switch
+                {
+                    VoluntaryLeavePath.LegacyUnknown => "legacy_unknown_voluntary_leave",
+                    VoluntaryLeavePath.LegacyDiscoveredBySync => "legacy_discovered_voluntary_leave",
+                    _ => "voluntary_leave"
+                };
+
+                logger.LogInformation(
+                    "Classifying {Member} as voluntary leave (path={Path}, status was {Status})",
+                    e.Member, path, member.Status);
+
+                await member.TransitionToAsync(db, MemberStatus.LeftVoluntarily, reason);
             }
             else
             {

--- a/src/Schema/MemberLifecycleClassifier.cs
+++ b/src/Schema/MemberLifecycleClassifier.cs
@@ -1,6 +1,29 @@
 namespace IgorBot.Schema;
 
 /// <summary>
+///     Describes which code path led to a <see cref="MemberStatus.LeftVoluntarily" /> classification.
+/// </summary>
+internal enum VoluntaryLeavePath
+{
+    /// <summary>
+    ///     Normal case: a member who went through onboarding (or at least had a known non-legacy status) left.
+    /// </summary>
+    Standard,
+
+    /// <summary>
+    ///     Legacy case: the document still has <see cref="MemberStatus.Unknown" /> — existed before any
+    ///     onboarding tracking was in place and was never touched by a startup migration.
+    /// </summary>
+    LegacyUnknown,
+
+    /// <summary>
+    ///     Pre-existing member first seen by <c>MemberDbSyncInvokable</c> and stamped
+    ///     <see cref="MemberStatus.New" /> with reason <c>"discovered_by_sync"</c>, but never onboarded.
+    /// </summary>
+    LegacyDiscoveredBySync
+}
+
+/// <summary>
 ///     Pure functions for classifying a member's departure type.
 ///     Extracted from <c>ApplicationWorkflow.MemberRemoved</c> so the logic can be unit-tested
 ///     without a Discord client or a database connection.
@@ -32,4 +55,33 @@ internal static class MemberLifecycleClassifier
             // Already in a terminal state set by a prior action — do not overwrite.
             _ => false
         };
+
+    /// <summary>
+    ///     Classifies *how* a voluntary leave came about so callers can attach a structured reason and
+    ///     emit a distinct log line for legacy/untracked cases.
+    /// </summary>
+    public static VoluntaryLeavePath ClassifyVoluntaryLeavePath(GuildMember member)
+    {
+        // Status was never resolved — document predates all onboarding tracking.
+        if (member.Status == MemberStatus.Unknown
+            && member.StatusHistory.Count == 0
+            && member.Application is null
+            && member.Channel is null)
+        {
+            return VoluntaryLeavePath.LegacyUnknown;
+        }
+
+        // Document was inserted by MemberDbSyncInvokable (stamped New with a single
+        // "discovered_by_sync" history entry) but the member left before ever being onboarded.
+        if (member.Status == MemberStatus.New
+            && member.Application is null
+            && member.Channel is null
+            && member.StatusHistory.Count == 1
+            && member.StatusHistory[0].Reason == "discovered_by_sync")
+        {
+            return VoluntaryLeavePath.LegacyDiscoveredBySync;
+        }
+
+        return VoluntaryLeavePath.Standard;
+    }
 }

--- a/src/Schema/MemberLifecycleClassifier.cs
+++ b/src/Schema/MemberLifecycleClassifier.cs
@@ -31,6 +31,15 @@ internal enum VoluntaryLeavePath
 internal static class MemberLifecycleClassifier
 {
     /// <summary>
+    ///     Reason string written to <see cref="MemberStatusEvent.Reason" /> and
+    ///     <see cref="GuildMember.StatusReason" /> when a document is first inserted by
+    ///     <c>MemberDbSyncInvokable</c>. Used as a sentinel by
+    ///     <see cref="ClassifyVoluntaryLeavePath" /> to identify pre-existing members
+    ///     who were never onboarded before leaving.
+    /// </summary>
+    internal const string DiscoveredBySyncReason = "discovered_by_sync";
+
+    /// <summary>
     ///     Returns <see langword="true" /> when a member's departure should be recorded as a voluntary leave.
     ///     Migrated documents (<see cref="MemberStatus" /> != <see cref="MemberStatus.Unknown" />) are eligible
     ///     when in a non-terminal active state.
@@ -77,7 +86,7 @@ internal static class MemberLifecycleClassifier
             && member.Application is null
             && member.Channel is null
             && member.StatusHistory.Count == 1
-            && member.StatusHistory[0].Reason == "discovered_by_sync")
+            && member.StatusHistory[0].Reason == DiscoveredBySyncReason)
         {
             return VoluntaryLeavePath.LegacyDiscoveredBySync;
         }

--- a/tests/IgorBot.Tests/Schema/MemberLifecycleClassifierTests.cs
+++ b/tests/IgorBot.Tests/Schema/MemberLifecycleClassifierTests.cs
@@ -104,7 +104,7 @@ public sealed class MemberLifecycleClassifierTests
             From = MemberStatus.Unknown,
             To = MemberStatus.New,
             At = DateTime.UtcNow,
-            Reason = "discovered_by_sync"
+            Reason = MemberLifecycleClassifier.DiscoveredBySyncReason
         });
 
         MemberLifecycleClassifier.ClassifyVoluntaryLeavePath(member)
@@ -149,7 +149,7 @@ public sealed class MemberLifecycleClassifierTests
             From = MemberStatus.Unknown,
             To = MemberStatus.New,
             At = DateTime.UtcNow.AddDays(-2),
-            Reason = "discovered_by_sync"
+            Reason = MemberLifecycleClassifier.DiscoveredBySyncReason
         });
         member.StatusHistory.Add(new MemberStatusEvent
         {
@@ -173,7 +173,7 @@ public sealed class MemberLifecycleClassifierTests
             From = MemberStatus.Unknown,
             To = MemberStatus.New,
             At = DateTime.UtcNow,
-            Reason = "discovered_by_sync"
+            Reason = MemberLifecycleClassifier.DiscoveredBySyncReason
         });
 
         MemberLifecycleClassifier.IsEligibleForVoluntaryLeave(member).Should().BeTrue();

--- a/tests/IgorBot.Tests/Schema/MemberLifecycleClassifierTests.cs
+++ b/tests/IgorBot.Tests/Schema/MemberLifecycleClassifierTests.cs
@@ -84,6 +84,101 @@ public sealed class MemberLifecycleClassifierTests
         MemberLifecycleClassifier.IsEligibleForVoluntaryLeave(member).Should().BeFalse();
     }
 
+    // ─── ClassifyVoluntaryLeavePath ──────────────────────────────────────────
+
+    [Fact]
+    public void ClassifyVoluntaryLeavePath_Unknown_NoHistoryNoApplication_ReturnsLegacyUnknown()
+    {
+        GuildMember member = BuildMember(MemberStatus.Unknown);
+
+        MemberLifecycleClassifier.ClassifyVoluntaryLeavePath(member)
+            .Should().Be(VoluntaryLeavePath.LegacyUnknown);
+    }
+
+    [Fact]
+    public void ClassifyVoluntaryLeavePath_New_SingleDiscoveredBySyncHistory_ReturnsLegacyDiscoveredBySync()
+    {
+        GuildMember member = BuildMember(MemberStatus.New);
+        member.StatusHistory.Add(new MemberStatusEvent
+        {
+            From = MemberStatus.Unknown,
+            To = MemberStatus.New,
+            At = DateTime.UtcNow,
+            Reason = "discovered_by_sync"
+        });
+
+        MemberLifecycleClassifier.ClassifyVoluntaryLeavePath(member)
+            .Should().Be(VoluntaryLeavePath.LegacyDiscoveredBySync);
+    }
+
+    [Fact]
+    public void ClassifyVoluntaryLeavePath_New_SingleHistoryWithDifferentReason_ReturnsStandard()
+    {
+        GuildMember member = BuildMember(MemberStatus.New);
+        member.StatusHistory.Add(new MemberStatusEvent
+        {
+            From = MemberStatus.Unknown,
+            To = MemberStatus.New,
+            At = DateTime.UtcNow,
+            Reason = "rejoin"
+        });
+
+        MemberLifecycleClassifier.ClassifyVoluntaryLeavePath(member)
+            .Should().Be(VoluntaryLeavePath.Standard);
+    }
+
+    [Theory]
+    [InlineData(MemberStatus.Onboarding)]
+    [InlineData(MemberStatus.QuestionnaireSubmitted)]
+    [InlineData(MemberStatus.FullMember)]
+    [InlineData(MemberStatus.StrangerRoleRemoved)]
+    public void ClassifyVoluntaryLeavePath_OnboardedStatuses_ReturnsStandard(MemberStatus status)
+    {
+        GuildMember member = BuildMember(status);
+
+        MemberLifecycleClassifier.ClassifyVoluntaryLeavePath(member)
+            .Should().Be(VoluntaryLeavePath.Standard);
+    }
+
+    [Fact]
+    public void ClassifyVoluntaryLeavePath_New_DiscoveredBySyncReason_ButMultipleHistoryEntries_ReturnsStandard()
+    {
+        GuildMember member = BuildMember(MemberStatus.New);
+        member.StatusHistory.Add(new MemberStatusEvent
+        {
+            From = MemberStatus.Unknown,
+            To = MemberStatus.New,
+            At = DateTime.UtcNow.AddDays(-2),
+            Reason = "discovered_by_sync"
+        });
+        member.StatusHistory.Add(new MemberStatusEvent
+        {
+            From = MemberStatus.New,
+            To = MemberStatus.New,
+            At = DateTime.UtcNow,
+            Reason = "rejoin"
+        });
+
+        MemberLifecycleClassifier.ClassifyVoluntaryLeavePath(member)
+            .Should().Be(VoluntaryLeavePath.Standard);
+    }
+
+    // Regression guard: a member discovered by sync is still eligible for voluntary leave.
+    [Fact]
+    public void IsEligibleForVoluntaryLeave_New_DiscoveredBySyncHistory_ReturnsTrue()
+    {
+        GuildMember member = BuildMember(MemberStatus.New);
+        member.StatusHistory.Add(new MemberStatusEvent
+        {
+            From = MemberStatus.Unknown,
+            To = MemberStatus.New,
+            At = DateTime.UtcNow,
+            Reason = "discovered_by_sync"
+        });
+
+        MemberLifecycleClassifier.IsEligibleForVoluntaryLeave(member).Should().BeTrue();
+    }
+
     // ─── Helpers ─────────────────────────────────────────────────────────────
 
     private static GuildMember BuildMember(MemberStatus status) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Newly discovered members are now initialized with a recorded membership status, timestamp, and reason to improve sync accuracy.
  * Member departures use a refined classification to determine voluntary-leave origins, producing clearer logs and more specific leave reasons.

* **Tests**
  * Added tests covering voluntary-leave classification and related eligibility across legacy and standard member scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/IgorBot/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->