### PR TITLE
Refactor GuildMemberStatusMigration with legacy doc support and member lifecycle reset

### DIFF
--- a/src/Modules/ApplicationWorkflow.MemberAdded.cs
+++ b/src/Modules/ApplicationWorkflow.MemberAdded.cs
@@ -30,7 +30,9 @@ internal partial class ApplicationWorkflow
 
         GuildMember? guildMember = await db.Find<GuildMember>().OneAsync(e.ToEntityId());
 
-        if (guildMember is null)
+        bool isFirstJoin = guildMember is null;
+
+        if (isFirstJoin)
         {
             guildMember = new GuildMember
             {
@@ -45,10 +47,26 @@ internal partial class ApplicationWorkflow
             logger.LogInformation("{Member} added to DB", e.Member);
         }
 
-        guildMember.JoinedAt = DateTime.UtcNow;
-        guildMember.Reset();
+        // guildMember is guaranteed non-null: either it existed before or was just created above.
+        GuildMember member = guildMember!;
+        member.JoinedAt = DateTime.UtcNow;
 
-        await db.SaveAsync(guildMember);
+        if (isFirstJoin)
+        {
+            // Brand-new member: initialize canonical state without recording a misleading "rejoin" history entry.
+            DateTime now = DateTime.UtcNow;
+            member.Status = MemberStatus.New;
+            member.StatusChangedAt = now;
+            member.StatusReason = "join";
+            logger.LogInformation("GuildMember {MemberId} initialized as New (first join)", member.ID);
+        }
+        else
+        {
+            // Returning member: reset lifecycle fields and record a rejoin history event.
+            member.Reset();
+        }
+
+        await db.SaveAsync(member);
 
         logger.LogInformation("{Member} updated in DB", e.Member);
         DiscordRole strangerRole = e.Guild.GetRole(guildConfig.StrangerRoleId);
@@ -64,7 +82,7 @@ internal partial class ApplicationWorkflow
         {
             logger.LogInformation("{Member} has stranger role, submitting workflow", e.Member);
 
-            await ProcessStrangerAssignment(e.Guild, guildConfig, guildMember);
+            await ProcessStrangerAssignment(e.Guild, guildConfig, member);
         }
     }
 }

--- a/src/Services/GuildMemberStatusMigration.cs
+++ b/src/Services/GuildMemberStatusMigration.cs
@@ -26,7 +26,9 @@ internal static class GuildMemberStatusMigration
         Log.Information("GuildMemberStatusMigration starting (dryRun={DryRun})", dryRun);
 
         List<GuildMember> unmigratedMembers = await db.Find<GuildMember>()
-            .ManyAsync(m => m.Eq(f => f.Status, MemberStatus.Unknown));
+            .ManyAsync(f => f.Or(
+                f.Eq(m => m.Status, MemberStatus.Unknown),
+                f.Exists(m => m.Status, false)));
 
         if (unmigratedMembers.Count == 0)
         {
@@ -126,7 +128,7 @@ internal static class GuildMemberStatusMigration
             return (MemberStatus.FullMember, m.PromotedAt ?? m.FullMemberAt!.Value);
         }
 
-        if (m.Application is not null && m.Application.QuestionnaireSubmittedAt.HasValue)
+        if (m.Application?.QuestionnaireSubmittedAt != null)
         {
             return (MemberStatus.QuestionnaireSubmitted, m.Application.QuestionnaireSubmittedAt.Value);
         }

--- a/src/Services/GuildMemberStatusMigration.cs
+++ b/src/Services/GuildMemberStatusMigration.cs
@@ -40,8 +40,22 @@ internal static class GuildMemberStatusMigration
 
         Dictionary<MemberStatus, int> histogram = new();
 
+        int skippedCount = 0;
+
         foreach (GuildMember member in unmigratedMembers)
         {
+            // Corrupted documents (e.g. created with a non-string _id before Phase 1) have a
+            // null ID after deserialization. SaveAsync would treat them as new documents and try
+            // to INSERT, producing a duplicate-key error. Skip them with a warning instead.
+            if (string.IsNullOrEmpty(member.ID))
+            {
+                Log.Warning(
+                    "GuildMemberStatusMigration: skipping document with null/empty ID (GuildId={GuildId}, MemberId={MemberId})",
+                    member.GuildId, member.MemberId);
+                skippedCount++;
+                continue;
+            }
+
             (MemberStatus derivedStatus, DateTime derivedAt) = DeriveStatus(member);
 
             histogram.TryGetValue(derivedStatus, out int existing);
@@ -57,27 +71,37 @@ internal static class GuildMemberStatusMigration
             Log.Information("Migrating {MemberId} {Unknown} -> {Derived} at {At}",
                 member.ID, MemberStatus.Unknown, derivedStatus, derivedAt);
 
-            member.Status = derivedStatus;
-            member.StatusChangedAt = derivedAt;
-
-            // Synthetic history entry so it is clear this came from migration
-            member.StatusHistory.Add(new MemberStatusEvent
+            MemberStatusEvent evt = new()
             {
                 From = MemberStatus.Unknown,
                 To = derivedStatus,
                 At = derivedAt,
                 Reason = "migration"
-            });
+            };
+
+            // Use an atomic $set + $push instead of SaveAsync so we can never accidentally
+            // INSERT a document (SaveAsync's insert-vs-replace is decided by HasDefaultID(),
+            // which is unreliable for legacy documents with unusual _id shapes).
+            Update<GuildMember> update = db.Update<GuildMember>()
+                .MatchID(member.ID)
+                .Modify(m => m.Status, derivedStatus)
+                .Modify(m => m.StatusChangedAt, (DateTime?)derivedAt)
+                .Modify(b => b.Push(m => m.StatusHistory, evt));
 
             // Mirror flags: keep RemovedByModeration accurate for legacy code paths
             if (derivedStatus is MemberStatus.KickedByModerator or MemberStatus.BannedByModerator
                 or MemberStatus.BannedByHoneypot or MemberStatus.BannedExternally
                 or MemberStatus.KickedExternally)
             {
-                member.RemovedByModeration = true;
+                update = update.Modify(m => m.RemovedByModeration, true);
             }
 
-            await db.SaveAsync(member);
+            await update.ExecuteAsync();
+        }
+
+        if (skippedCount > 0)
+        {
+            Log.Warning("GuildMemberStatusMigration: skipped {Count} documents with null/empty ID", skippedCount);
         }
 
         // Always log the histogram regardless of dry-run

--- a/src/Services/GuildMemberStatusMigration.cs
+++ b/src/Services/GuildMemberStatusMigration.cs
@@ -21,7 +21,7 @@ internal static class GuildMemberStatusMigration
     ///     When <c>true</c>, log what would be done but do NOT write to the database.
     ///     Safe to run repeatedly for verification.
     /// </param>
-    public static async Task RunAsync(DB db, bool dryRun = false)
+    public static async Task RunAsync(DB db, bool dryRun = false, Func<Task>? beforeUpdateHook = null)
     {
         Log.Information("GuildMemberStatusMigration starting (dryRun={DryRun})", dryRun);
 
@@ -100,6 +100,11 @@ internal static class GuildMemberStatusMigration
                 or MemberStatus.KickedExternally)
             {
                 update = update.Modify(m => m.RemovedByModeration, true);
+            }
+
+            if (beforeUpdateHook is not null)
+            {
+                await beforeUpdateHook();
             }
 
             await update.ExecuteAsync();

--- a/src/Services/GuildMemberStatusMigration.cs
+++ b/src/Services/GuildMemberStatusMigration.cs
@@ -82,8 +82,14 @@ internal static class GuildMemberStatusMigration
             // Use an atomic $set + $push instead of SaveAsync so we can never accidentally
             // INSERT a document (SaveAsync's insert-vs-replace is decided by HasDefaultID(),
             // which is unreliable for legacy documents with unusual _id shapes).
+            // The write-side predicate mirrors the read-side filter: if another writer
+            // (e.g. TransitionToAsync) already set a real Status between our Find and this
+            // update, the updateOne matches 0 documents and becomes a safe no-op.
             Update<GuildMember> update = db.Update<GuildMember>()
                 .MatchID(member.ID)
+                .Match(f => f.Or(
+                    f.Eq(m => m.Status, MemberStatus.Unknown),
+                    f.Exists(m => m.Status, false)))
                 .Modify(m => m.Status, derivedStatus)
                 .Modify(m => m.StatusChangedAt, (DateTime?)derivedAt)
                 .Modify(b => b.Push(m => m.StatusHistory, evt));

--- a/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
+++ b/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
@@ -306,20 +306,22 @@ public sealed class GuildMemberStatusMigrationDbTests : IAsyncLifetime
     [Fact]
     public async Task RunAsync_WriteSidePredicate_DoesNotOverwriteConcurrentlyMigratedDoc()
     {
-        // Arrange: insert a legacy doc that the outer Find would return (Status=Unknown).
+        // Arrange: doc starts with Status=Unknown so the Find picks it up.
         GuildMember m = await InsertUnmigrated(leftAt: DateTime.UtcNow.AddHours(-1));
 
-        // Simulate a concurrent TransitionToAsync winning the race: directly stamp a real status
-        // on the document in the DB before RunAsync issues its updateOne.
-        await _db.Update<GuildMember>()
-            .MatchID(m.ID)
-            .Modify(x => x.Status, MemberStatus.FullMember)
-            .ExecuteAsync();
+        // Act: inject a hook that fires after Find (document is already in the candidate list)
+        // but before the updateOne — this is the exact window the write-side predicate guards.
+        // The hook simulates a concurrent TransitionToAsync that wins the race.
+        await GuildMemberStatusMigration.RunAsync(_db, beforeUpdateHook: async () =>
+        {
+            await _db.Update<GuildMember>()
+                .MatchID(m.ID)
+                .Modify(x => x.Status, MemberStatus.FullMember)
+                .ExecuteAsync();
+        });
 
-        // Act: migration runs; its write-side predicate sees Status != Unknown → no-op.
-        await GuildMemberStatusMigration.RunAsync(_db);
-
-        // Assert: the concurrent winner's status is preserved; no "migration" history entry.
+        // Assert: the write-side predicate sees Status != Unknown and makes the updateOne a
+        // no-op; the concurrent winner's status and empty history are preserved.
         GuildMember loaded = await Reload(m);
         loaded.Status.Should().Be(MemberStatus.FullMember,
             because: "the write-side predicate must not overwrite a status set after the Find");

--- a/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
+++ b/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
@@ -304,6 +304,30 @@ public sealed class GuildMemberStatusMigrationDbTests : IAsyncLifetime
     // ─── Corrupted document with null _id is skipped gracefully ─────────────
 
     [Fact]
+    public async Task RunAsync_WriteSidePredicate_DoesNotOverwriteConcurrentlyMigratedDoc()
+    {
+        // Arrange: insert a legacy doc that the outer Find would return (Status=Unknown).
+        GuildMember m = await InsertUnmigrated(leftAt: DateTime.UtcNow.AddHours(-1));
+
+        // Simulate a concurrent TransitionToAsync winning the race: directly stamp a real status
+        // on the document in the DB before RunAsync issues its updateOne.
+        await _db.Update<GuildMember>()
+            .MatchID(m.ID)
+            .Modify(x => x.Status, MemberStatus.FullMember)
+            .ExecuteAsync();
+
+        // Act: migration runs; its write-side predicate sees Status != Unknown → no-op.
+        await GuildMemberStatusMigration.RunAsync(_db);
+
+        // Assert: the concurrent winner's status is preserved; no "migration" history entry.
+        GuildMember loaded = await Reload(m);
+        loaded.Status.Should().Be(MemberStatus.FullMember,
+            because: "the write-side predicate must not overwrite a status set after the Find");
+        loaded.StatusHistory.Should().BeEmpty(
+            because: "no migration event must be appended when the update is a no-op");
+    }
+
+    [Fact]
     public async Task RunAsync_DocumentWithNullId_IsSkippedWithoutCrash()
     {
         // Arrange: insert a corrupted document whose _id is BsonNull — this is what the C#

--- a/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
+++ b/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
@@ -3,6 +3,8 @@ using FluentAssertions;
 using IgorBot.Schema;
 using IgorBot.Services;
 
+using MongoDB.Bson;
+using MongoDB.Driver;
 using MongoDB.Entities;
 
 namespace IgorBot.Tests.Integration;
@@ -238,4 +240,64 @@ public sealed class GuildMemberStatusMigrationDbTests : IAsyncLifetime
     }
 
     private static string UniqueId() => Guid.NewGuid().ToString("N")[..16];
+
+    // ─── Legacy shape regression (no Status field in BSON) ───────────────────
+
+    /// <summary>
+    ///     Reproduces the true production legacy shape: a raw BSON document written before Phase 2
+    ///     that has no <c>Status</c> field at all (not even <c>Status: 0</c>).
+    /// </summary>
+    private async Task<string> InsertLegacyRaw(
+        DateTime? leftAt = null,
+        DateTime? kickedAt = null,
+        DateTime? bannedAt = null,
+        DateTime? promotedAt = null)
+    {
+        string id = UniqueId();
+
+        // Bypass MongoDB.Entities serialization so Status is genuinely absent.
+        IMongoCollection<GuildMember> typedColl = _db.Collection<GuildMember>();
+        IMongoCollection<BsonDocument> rawColl =
+            typedColl.Database.GetCollection<BsonDocument>(typedColl.CollectionNamespace.CollectionName);
+
+        BsonDocument doc = new()
+        {
+            ["_id"] = id,
+            ["MemberId"] = new BsonInt64(2),
+            ["GuildId"] = new BsonInt64(1),
+            ["Application"] = BsonNull.Value,
+            ["Channel"] = BsonNull.Value,
+            ["CreatedAt"] = new BsonDateTime(DateTime.UtcNow.AddDays(-1)),
+            ["JoinedAt"] = new BsonDateTime(DateTime.UtcNow.AddDays(-1)),
+            ["LeftAt"] = leftAt.HasValue ? new BsonDateTime(leftAt.Value) : BsonNull.Value,
+            ["PromotedAt"] = promotedAt.HasValue ? new BsonDateTime(promotedAt.Value) : BsonNull.Value,
+            ["KickedAt"] = kickedAt.HasValue ? new BsonDateTime(kickedAt.Value) : BsonNull.Value,
+            ["BannedAt"] = bannedAt.HasValue ? new BsonDateTime(bannedAt.Value) : BsonNull.Value,
+            ["Member"] = $"Member {id}; legacy#0000 (legacy)",
+            ["Mention"] = $"<@!{id}>"
+            // Intentionally no "Status" key — this is the pre-Phase-2 shape
+        };
+
+        await rawColl.InsertOneAsync(doc);
+        return id;
+    }
+
+    [Fact]
+    public async Task RunAsync_LegacyDocWithoutStatusField_IsMigrated()
+    {
+        // Arrange: insert a raw legacy document that has no Status field (true production shape)
+        string id = await InsertLegacyRaw(leftAt: DateTime.UtcNow.AddHours(-1));
+
+        // Act
+        await GuildMemberStatusMigration.RunAsync(_db);
+
+        // Assert
+        GuildMember? loaded = await _db.Find<GuildMember>().OneAsync(id);
+        loaded.Should().NotBeNull(because: "the raw legacy document must be findable after migration");
+        loaded!.Status.Should().Be(MemberStatus.LeftVoluntarily,
+            because: "LeftAt is set so the member left voluntarily");
+        loaded.StatusHistory.Should().ContainSingle(
+            because: "migration must append exactly one history event");
+        loaded.StatusHistory[0].Reason.Should().Be("migration");
+    }
 }

--- a/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
+++ b/tests/IgorBot.Tests/Integration/GuildMemberStatusMigrationDbTests.cs
@@ -300,4 +300,40 @@ public sealed class GuildMemberStatusMigrationDbTests : IAsyncLifetime
             because: "migration must append exactly one history event");
         loaded.StatusHistory[0].Reason.Should().Be("migration");
     }
+
+    // ─── Corrupted document with null _id is skipped gracefully ─────────────
+
+    [Fact]
+    public async Task RunAsync_DocumentWithNullId_IsSkippedWithoutCrash()
+    {
+        // Arrange: insert a corrupted document whose _id is BsonNull — this is what the C#
+        // driver deserializes to string ID = null, triggering the SaveAsync → INSERT → DupKey
+        // crash that was observed in production.
+        IMongoCollection<GuildMember> typedColl = _db.Collection<GuildMember>();
+        IMongoCollection<BsonDocument> rawColl =
+            typedColl.Database.GetCollection<BsonDocument>(typedColl.CollectionNamespace.CollectionName);
+
+        BsonDocument corrupted = new()
+        {
+            ["_id"] = BsonNull.Value,
+            ["MemberId"] = new BsonInt64(99),
+            ["GuildId"] = new BsonInt64(1),
+            ["JoinedAt"] = new BsonDateTime(DateTime.UtcNow.AddDays(-1)),
+            ["LeftAt"] = new BsonDateTime(DateTime.UtcNow.AddHours(-1)),
+            ["Member"] = "corrupted#0000",
+            ["Mention"] = "<@!99>"
+        };
+        await rawColl.InsertOneAsync(corrupted);
+
+        // Also insert one healthy legacy doc so we can verify normal migration still completes.
+        string healthyId = await InsertLegacyRaw(leftAt: DateTime.UtcNow.AddHours(-2));
+
+        // Act — must not throw
+        await GuildMemberStatusMigration.RunAsync(_db);
+
+        // Assert: the healthy document was migrated; the corrupted one was skipped.
+        GuildMember? healthy = await _db.Find<GuildMember>().OneAsync(healthyId);
+        healthy!.Status.Should().Be(MemberStatus.LeftVoluntarily,
+            because: "healthy legacy doc must still be migrated despite the corrupted peer");
+    }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Migration now handles legacy records missing a status, performs atomic status/history updates, preserves kicked/banned semantics, and skips corrupted documents without crashing.

* **New Features**
  * Member-join handling distinguishes first-time joins from returning members, initializing lifecycle fields for new members and resetting returning members.

* **Tests**
  * Added integration tests validating legacy-document migration, skipping of corrupted (null-id) docs, and that concurrent updates are not overwritten.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/IgorBot/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->